### PR TITLE
Remove default headers for public acl

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ gulp upload --dry
 
 #### options.headers
 
-Type: `Array`          
+Type: `Array`
 Default: `[]`
 
 Headers to set to each file uploaded to S3
@@ -53,7 +53,12 @@ Headers to set to each file uploaded to S3
 var gulp = require("gulp");
 var s3 = require("gulp-s3-ls");
 var aws = require("./aws.json");
-var options = { headers: {'Cache-Control': 'max-age=315360000, no-transform, public'} };
+var options = {
+  headers: {
+    'Cache-Control': 'max-age=315360000, no-transform, public',
+    'x-amz-acl': 'public-read'
+  }
+};
 
 gulp.src('./dist/**', {read: false})
     .pipe(s3(aws, options));
@@ -61,7 +66,7 @@ gulp.src('./dist/**', {read: false})
 
 #### options.gzippedOnly
 
-Type: `Boolean`          
+Type: `Boolean`
 Default: `false`
 
 Only upload files with .gz extension, additionally it will remove the .gz suffix on destination filename and set appropriate Content-Type and Content-Encoding headers.

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (aws, options) {
 
       var uploadPath = file.path.replace(file.base, options.uploadPath || '');
       uploadPath = uploadPath.replace(new RegExp('\\\\', 'g'), '/');
-      var headers = { 'x-amz-acl': 'public-read' };
+      var headers = {};
       if (options.headers) {
           for (var key in options.headers) {
               headers[key] = options.headers[key];


### PR DESCRIPTION
Removed the default headers, but I think you should up the semantic version, so this does not break any users who may expect the public header to be set by default.
#7
